### PR TITLE
Feature: UserSet

### DIFF
--- a/src/Acquisition.cs
+++ b/src/Acquisition.cs
@@ -12,7 +12,7 @@ namespace VL.Devices.IDS
 {
     internal class Acquisition : IVideoPlayer
     {
-        public static Acquisition? Start(VideoIn videoIn, DeviceDescriptor deviceDescriptor, ILogger logger, Int2 resolution, int fps, IConfiguration? configuration)
+        public static Acquisition? Start(VideoIn videoIn, DeviceDescriptor deviceDescriptor, ILogger logger, Int2 resolution, int fps, IConfiguration? configuration, string defaultUserSet)
         {
             logger.Log(LogLevel.Information, "Starting image acquisition on {device}", deviceDescriptor.DisplayName());
 
@@ -48,7 +48,7 @@ namespace VL.Devices.IDS
             // and wait until execution is finished
             try
             {
-                nodeMapRemoteDevice.FindNode<EnumerationNode>("UserSetSelector").SetCurrentEntry("Default");
+                nodeMapRemoteDevice.FindNode<EnumerationNode>("UserSetSelector").SetCurrentEntry(defaultUserSet);
                 nodeMapRemoteDevice.FindNode<CommandNode>("UserSetLoad").Execute();
                 nodeMapRemoteDevice.FindNode<CommandNode>("UserSetLoad").WaitUntilDone();
             }

--- a/src/Enumerations.cs
+++ b/src/Enumerations.cs
@@ -8,7 +8,7 @@ namespace VL.Devices.IDS
 {
     public class Enumerations
     {
-        public enum UserSetDefault
+        public enum UserSetSelector
         {
             Default,
             HighSpeed,

--- a/src/Enumerations.cs
+++ b/src/Enumerations.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VL.Devices.IDS
+{
+    public class Enumerations
+    {
+        public enum UserSetDefault
+        {
+            Default,
+            HighSpeed,
+            Linescan,
+            LinescanHighSpeed,
+            LongExposure,
+            UserSet0,
+            UserSet1
+        }
+    }
+}

--- a/src/VideoIn.cs
+++ b/src/VideoIn.cs
@@ -22,6 +22,7 @@ namespace VL.Devices.IDS
         private int _fps;
         private IConfiguration? _configuration;
         private bool _enabled;
+        private string _defaultUserSet;
 
         internal string Info { get; set; } = "";
         internal Spread<PropertyInfo> PropertyInfos { get; set; } = new SpreadBuilder<PropertyInfo>().ToSpread();
@@ -39,6 +40,7 @@ namespace VL.Devices.IDS
             [DefaultValue("30")] int FPS,
             IConfiguration configuration,
             [DefaultValue("true")] bool enabled,
+            [DefaultValue("Default")] string defaultUserSet,
             out string Info)
         {
             // By comparing the descriptor we can be sure that on re-connect of the device we see the change
@@ -49,6 +51,7 @@ namespace VL.Devices.IDS
                 _fps = FPS;
                 _configuration = configuration;
                 _enabled = enabled;
+                _defaultUserSet = defaultUserSet;
                 _changedTicket++;
             }
 
@@ -69,7 +72,7 @@ namespace VL.Devices.IDS
 
             try
             {
-                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration);
+                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration, _defaultUserSet);
                 _aquicitionStarted.OnNext(result);
                 return result;
             }

--- a/src/VideoIn.cs
+++ b/src/VideoIn.cs
@@ -22,7 +22,7 @@ namespace VL.Devices.IDS
         private int _fps;
         private IConfiguration? _configuration;
         private bool _enabled;
-        private string _defaultUserSet;
+        private string? _defaultUserSet;
 
         internal string Info { get; set; } = "";
         internal Spread<PropertyInfo> PropertyInfos { get; set; } = new SpreadBuilder<PropertyInfo>().ToSpread();
@@ -40,11 +40,11 @@ namespace VL.Devices.IDS
             [DefaultValue("30")] int FPS,
             IConfiguration configuration,
             [DefaultValue("true")] bool enabled,
-            [DefaultValue("Default")] string defaultUserSet,
+            [Pin(Visibility = PinVisibility.Optional), DefaultValue("Default")] string defaultUserSet,
             out string Info)
         {
             // By comparing the descriptor we can be sure that on re-connect of the device we see the change
-            if (device?.Tag != _device || resolution != _resolution || FPS != _fps || configuration != _configuration || enabled != _enabled)
+            if (device?.Tag != _device || resolution != _resolution || FPS != _fps || configuration != _configuration || enabled != _enabled || defaultUserSet != _defaultUserSet)
             {
                 _device = device?.Tag as DeviceDescriptor;
                 _resolution = resolution;
@@ -72,7 +72,7 @@ namespace VL.Devices.IDS
 
             try
             {
-                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration, _defaultUserSet);
+                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration, _defaultUserSet ?? "Default");
                 _aquicitionStarted.OnNext(result);
                 return result;
             }

--- a/src/VideoIn.cs
+++ b/src/VideoIn.cs
@@ -23,7 +23,7 @@ namespace VL.Devices.IDS
         private int _fps;
         private IConfiguration? _configuration;
         private bool _enabled;
-        private UserSetDefault _defaultUserSet;
+        private UserSetSelector _defaultUserSet;
 
         internal string Info { get; set; } = "";
         internal Spread<PropertyInfo> PropertyInfos { get; set; } = new SpreadBuilder<PropertyInfo>().ToSpread();
@@ -40,19 +40,19 @@ namespace VL.Devices.IDS
             [DefaultValue("640, 480")] Int2 resolution,
             [DefaultValue("30")] int FPS,
             IConfiguration configuration,
-            [Pin(Name = "UserSet Default", Visibility = PinVisibility.Optional), DefaultValue("Default")] UserSetDefault UserSetDefault,
+            [Pin(Name = "UserSet", Visibility = PinVisibility.Optional), DefaultValue("Default")] UserSetSelector UserSet,
             [DefaultValue("true")] bool enabled,
             out string Info)
         {
             // By comparing the descriptor we can be sure that on re-connect of the device we see the change
-            if (device?.Tag != _device || resolution != _resolution || FPS != _fps || configuration != _configuration || enabled != _enabled || UserSetDefault != _defaultUserSet)
+            if (device?.Tag != _device || resolution != _resolution || FPS != _fps || configuration != _configuration || enabled != _enabled || UserSet != _defaultUserSet)
             {
                 _device = device?.Tag as DeviceDescriptor;
                 _resolution = resolution;
                 _fps = FPS;
                 _configuration = configuration;
                 _enabled = enabled;
-                _defaultUserSet = UserSetDefault;
+                _defaultUserSet = UserSet;
                 _changedTicket++;
             }
 

--- a/src/VideoIn.cs
+++ b/src/VideoIn.cs
@@ -6,6 +6,7 @@ using VL.Model;
 using System.Reactive.Subjects;
 using System.Reactive.Linq;
 using VL.Devices.IDS.Advanced;
+using static VL.Devices.IDS.Enumerations;
 
 namespace VL.Devices.IDS
 {
@@ -22,7 +23,7 @@ namespace VL.Devices.IDS
         private int _fps;
         private IConfiguration? _configuration;
         private bool _enabled;
-        private string? _defaultUserSet;
+        private UserSetDefault _defaultUserSet;
 
         internal string Info { get; set; } = "";
         internal Spread<PropertyInfo> PropertyInfos { get; set; } = new SpreadBuilder<PropertyInfo>().ToSpread();
@@ -39,19 +40,19 @@ namespace VL.Devices.IDS
             [DefaultValue("640, 480")] Int2 resolution,
             [DefaultValue("30")] int FPS,
             IConfiguration configuration,
+            [Pin(Name = "UserSet Default", Visibility = PinVisibility.Optional), DefaultValue("Default")] UserSetDefault UserSetDefault,
             [DefaultValue("true")] bool enabled,
-            [Pin(Visibility = PinVisibility.Optional), DefaultValue("Default")] string defaultUserSet,
             out string Info)
         {
             // By comparing the descriptor we can be sure that on re-connect of the device we see the change
-            if (device?.Tag != _device || resolution != _resolution || FPS != _fps || configuration != _configuration || enabled != _enabled || defaultUserSet != _defaultUserSet)
+            if (device?.Tag != _device || resolution != _resolution || FPS != _fps || configuration != _configuration || enabled != _enabled || UserSetDefault != _defaultUserSet)
             {
                 _device = device?.Tag as DeviceDescriptor;
                 _resolution = resolution;
                 _fps = FPS;
                 _configuration = configuration;
                 _enabled = enabled;
-                _defaultUserSet = defaultUserSet;
+                _defaultUserSet = UserSetDefault;
                 _changedTicket++;
             }
 
@@ -72,7 +73,7 @@ namespace VL.Devices.IDS
 
             try
             {
-                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration, _defaultUserSet ?? "Default");
+                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration, _defaultUserSet.ToString() ?? "Default");
                 _aquicitionStarted.OnNext(result);
                 return result;
             }

--- a/src/VideoIn.cs
+++ b/src/VideoIn.cs
@@ -73,7 +73,7 @@ namespace VL.Devices.IDS
 
             try
             {
-                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration, _defaultUserSet.ToString() ?? "Default");
+                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration, _defaultUserSet.ToString());
                 _aquicitionStarted.OnNext(result);
                 return result;
             }


### PR DESCRIPTION
adds ability to define the default UserSet on VideoIn. can be used to retrieve complete configuration that was stored in camera by e.g. peak studio.

usage:
- open peak studio
- change some properties (ideally some that aren't changable with the nodeset, like ROI or Binning)
- save the configuration in UserSet0
- open VL and ids overview helppatch
- change the" Default User Set"-Input from Default to UserSet0
- restart aquisition via Enabled or F9
- the settings made with peak should now be aplied
- note: you can still use ConfigProperty Nodes to change specific parameters

One thing i couldn't find out:
How to make this new pin hidden? is there an attribute for that?

closes #8 