### PR TITLE
Hot pixel correction

### DIFF
--- a/src/Acquisition.cs
+++ b/src/Acquisition.cs
@@ -316,10 +316,10 @@ namespace VL.Devices.IDS
             if (_correctHotPixels)
             {
                 var vec = _m_hotpixelCorrection.Detect(bayerImage);
-                var correctedImage = _m_hotpixelCorrection.Correct(bayerImage, vec);
+                using var correctedImage = _m_hotpixelCorrection.Correct(bayerImage, vec);
 
                 // Debayering and convert IDS peak IPL Image to RGB8 format
-                bgraImage = _imageConverter.Convert(_m_hotpixelCorrection.Correct(correctedImage, vec), PixelFormat);
+                bgraImage = _imageConverter.Convert(correctedImage, PixelFormat);
             }
             else
             {

--- a/src/Acquisition.cs
+++ b/src/Acquisition.cs
@@ -293,6 +293,7 @@ namespace VL.Devices.IDS
             _imageConverter.Dispose();
             _device.Dispose();
             _idsPeakLibSubscription.Dispose();
+            _m_hotpixelCorrection?.Dispose();
         }
 
         public unsafe IResourceProvider<VideoFrame>? GrabVideoFrame()

--- a/src/VideoIn.cs
+++ b/src/VideoIn.cs
@@ -22,6 +22,7 @@ namespace VL.Devices.IDS
         private int _fps;
         private IConfiguration? _configuration;
         private bool _enabled;
+        private bool _correctHotPixels;
 
         internal string Info { get; set; } = "";
         internal Spread<PropertyInfo> PropertyInfos { get; set; } = new SpreadBuilder<PropertyInfo>().ToSpread();
@@ -38,17 +39,19 @@ namespace VL.Devices.IDS
             [DefaultValue("640, 480")] Int2 resolution,
             [DefaultValue("30")] int FPS,
             IConfiguration configuration,
+            [Pin(Visibility = PinVisibility.Optional), DefaultValue("true")] bool CorrectHotPixels,
             [DefaultValue("true")] bool enabled,
             out string Info)
         {
             // By comparing the descriptor we can be sure that on re-connect of the device we see the change
-            if (device?.Tag != _device || resolution != _resolution || FPS != _fps || configuration != _configuration || enabled != _enabled)
+            if (device?.Tag != _device || resolution != _resolution || FPS != _fps || configuration != _configuration || enabled != _enabled || CorrectHotPixels != _correctHotPixels)
             {
                 _device = device?.Tag as DeviceDescriptor;
                 _resolution = resolution;
                 _fps = FPS;
                 _configuration = configuration;
                 _enabled = enabled;
+                _correctHotPixels = CorrectHotPixels;
                 _changedTicket++;
             }
 
@@ -69,7 +72,7 @@ namespace VL.Devices.IDS
 
             try
             {
-                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration);
+                var result = Acquisition.Start(this, device, _logger, _resolution, _fps, _configuration, _correctHotPixels);
                 _aquicitionStarted.OnNext(result);
                 return result;
             }


### PR DESCRIPTION
see https://en.ids-imaging.com/manuals/ids-peak/ids-peak-user-manual/2.14.0/en/program-correct-hotpixel.html for reference.

it is implemented as a new optional bool Pin on the VideoIn Node. By default it's True, because that is 'always' needed/expected by a user.

NOTE:
this PR is based on #9